### PR TITLE
Fix Windows support (at least for building in MSYS2)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include "instance/instance.h"
 #include "master/master.h"
 #include "status/status.h"
+#include "net.h"
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,6 +36,13 @@ int main(int argc, const char *argv[]) {
 		return -1;
 	}
 	#endif
+
+	if (!sockets_init())
+	{
+		fprintf(stderr, "Couldn't initialize sockets subsystem\n");
+		return -1;
+	}
+
 	memset(&cfg, 0, sizeof(cfg));
 	if(config_load(&cfg, config_path)) // TODO: live config reloading
 		goto fail0;

--- a/src/net.h
+++ b/src/net.h
@@ -12,6 +12,7 @@
 #ifdef WINDOWS
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <Windef.h>
 #define SHUT_RD SD_RECEIVE
 #define SHUT_RDWR SD_BOTH
 typedef int socklen_t;
@@ -31,6 +32,11 @@ typedef int socklen_t;
 #define NET_RESEND_DELAY 27
 
 #define NET_THREAD_INVALID 0 // TODO: this macro marks all non-portable uses of the pthreads API
+
+char* net_get_error_str();
+char* net_get_error_str_from(int);
+
+bool sockets_init();
 
 struct SS {
 	socklen_t len;

--- a/src/status/status.c
+++ b/src/status/status.c
@@ -2,7 +2,6 @@
 #include "internal.h"
 #include <unistd.h>
 #include <string.h>
-#include <errno.h>
 
 struct Context {
 	int32_t listenfd;
@@ -44,7 +43,7 @@ bool status_init(const char *path, uint16_t port) {
 			.sin6_scope_id = 0,
 		};
 		if(bind(ctx.listenfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {
-			uprintf("Cannot bind socket to port %hu: %s\n", port, strerror(errno));
+			uprintf("Cannot bind socket to port %hu: %s\n", port, net_get_error_str());
 			close(ctx.listenfd);
 			ctx.listenfd = -1;
 			return true;

--- a/src/status/status_ssl.c
+++ b/src/status/status_ssl.c
@@ -8,7 +8,6 @@
 #include <unistd.h>
 #include <signal.h>
 #include <string.h>
-#include <errno.h>
 
 struct Context {
 	int32_t listenfd;
@@ -98,7 +97,7 @@ bool status_ssl_init(mbedtls_x509_crt certs[2], mbedtls_pk_context keys[2], cons
 		signal(SIGPIPE, SIG_IGN);
 		#endif
 		if(bind(ctx.listenfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {
-			uprintf("Cannot bind socket to port %hu: %s\n", port, strerror(errno));
+			uprintf("Cannot bind socket to port %hu: %s\n", port, net_get_error_str());
 			close(ctx.listenfd);
 			ctx.listenfd = -1;
 			return true;


### PR DESCRIPTION
- All socket calls using winsock2 require WSAStartup to be called, so do that from main.c
- Socket calls now have generic error handling that checks either errno or WSAGetLastError depending on platform
- We have to read the config json with "rb", so that the file length check doesn't fail: reading with "r" collapses "\r\n" on Windows (the json parser seems to handle the unmodified EOLs just fine)